### PR TITLE
5270 expose selected nodes in iframe

### DIFF
--- a/src/scripts/playbookTypes.ts
+++ b/src/scripts/playbookTypes.ts
@@ -8,5 +8,34 @@ export interface WorkflowWindowMessageData {
     | 'WrapperOriginSetOnComfyInstance'
     | 'SendWrapperOriginToComfyWindow'
     | 'SendWorkflowDataToPlaybookWrapper'
-  data?: ComfyWorkflowJSON
+    | 'SendSelectedNodesToPlaybookWrapper'
+  data?: any
+}
+
+/** This type matches one of the same name in Playbook front end repo. */
+export type ComfyWorkflowNodeData = {
+  id: number
+  type: string
+  widgets_values: any[]
+  widgets: any[]
+  title: string
+  inputs: {
+    link: number
+    name: string
+    type: string
+    slot_index: number
+  }[]
+  outputs: {
+    links: number[]
+    name: string
+    shape: number
+    slot_index: number
+    type: string
+  }[]
+  properties: any
+  /** Index 0 is x, index 1 is y. */
+  pos: Float32Array
+  /** Index 0 is width, index 1 is height. */
+  size: Float32Array
+  flags: any
 }

--- a/src/scripts/ui.ts
+++ b/src/scripts/ui.ts
@@ -433,7 +433,9 @@ export class ComfyUI {
       [$el('div'), $el('div'), $el('div')]
     ) as HTMLDivElement
 
-    this.menuContainer = $el('div.comfy-menu', { parent: containerElement }, [
+    // The propsOrChildren prop has been set to null to remove menu panel
+    // for use in the Playbook wrapper (previous value was '{ parent: containerElement }').
+    this.menuContainer = $el('div.comfy-menu', null, [
       $el(
         'div.drag-handle.comfy-menu-header',
         {


### PR DESCRIPTION
- On. graph load, subscribe a selection change listener. This listener will broadcast node selection changes to the Playbook wrapper.
- Create type ComfyWorkflowNodeData to enforce type-matching between outgoing message and Playbook wrapper expectations.